### PR TITLE
Add GitHub action workflows into develop branch

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,7 @@ Checks: '*,
 
 WarningsAsErrors: '*'
 
-HeaderFilterRegex: 'minesweeper\/.*\.(h|hpp)$'
+HeaderFilterRegex: 'minesweeper\/[^\\\/]+\.(h|hpp|tpp)$'
 
 CheckOptions:
   - key: readability-identifier-naming.ClassCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,11 +1,48 @@
 ---
+
+# Check exclude reasoning:
+#
+# * [modernize-use-trailing-return-type]:
+#       "use a trailing return type for this function" (applies to all functions)
+# * [fuchsia-default-arguments-calls]:
+#       "calling a function that uses a default argument is disallowed"
+# * [fuchsia-default-arguments-declarations]:
+#       "Warns if a function or method is declared with default parameters."
+# * [llvm-header-guard]:
+#       does not work properly on Windows style paths?
+# * [google-runtime-references]:
+#       "non-const reference parameter, make it const or use a pointer"
+# * [hicpp-special-member-functions]:
+#       alias of 'cppcoreguidelines-special-member-functions'
+# * [cppcoreguidelines-pro-bounds-array-to-pointer-decay]:
+#       triggered by 'assert'
+# * [hicpp-no-array-decay]:
+#       alias of 'cppcoreguidelines-pro-bounds-array-to-pointer-decay'
+# * [llvmlibc-restrict-system-libc-headers]:
+#       triggered by system includes
+# * [llvmlibc-callee-namespace]:
+#       "Checks all calls resolve to functions within __llvm_libc namespace."
+# * [llvmlibc-implementation-in-namespace]:
+#       "'__llvm_libc' needs to be the outermost namespace"
+# * [cppcoreguidelines-avoid-non-const-global-variables]:
+#       causes problems with private static fields
+#         * https://bugs.llvm.org/show_bug.cgi?id=48040
+#         * https://stackoverflow.com/questions/64680769/c-core-guidelines-for-static-member-variables
+
+
 Checks: '*,
         -modernize-use-trailing-return-type,
         -fuchsia-default-arguments-calls,
         -fuchsia-default-arguments-declarations,
         -llvm-header-guard,
         -google-runtime-references,
-        -hicpp-special-member-functions'
+        -hicpp-special-member-functions,
+        -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+        -hicpp-no-array-decay,
+        -llvmlibc-restrict-system-libc-headers,
+        -llvmlibc-callee-namespace,
+        -llvmlibc-implementation-in-namespace,
+        -cppcoreguidelines-avoid-non-const-global-variables'
 
 WarningsAsErrors: '*'
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,31 @@
+name: clang-format
+
+on: [push, pull_request]
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # This is needed together with PAT to allow triggering push workflow event from this action.
+        # https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854
+        persist-credentials: false
+
+    - uses: DoozyX/clang-format-lint-action@v0.11
+      with:
+        source: '.'
+        exclude: './extern'
+        extensions: 'h,cpp,tpp'
+        clangFormatVersion: 10
+        inplace: True
+
+    - uses: EndBug/add-and-commit@v4
+      with:
+        author_name: Clang-format Robot
+        author_email: timi.makkonen@gmail.com
+        message: 'Format code using ''clang-format'''
+      env:
+        # PAT needed to allow triggering push workflow event from this action.
+        GITHUB_TOKEN: ${{ secrets.MY_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -9,6 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        submodules: true
         # This is needed together with PAT to allow triggering push workflow event from this action.
         # https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854
         persist-credentials: false

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,55 @@
+name: clang-tidy
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    env:
+      CLANG_TIDY_CMAKE_OPTION_NAME: MINESWEEPER_CLANG_TIDY
+      CLANG_TIDY_VERSION: 10
+    
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build-type: [Release, Debug]
+
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Install clang-tidy-${{env.CLANG_TIDY_VERSION}}
+      shell: bash
+      run: |
+        sudo apt-get install -y clang-tidy-${{env.CLANG_TIDY_VERSION}}
+        sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-${{env.CLANG_TIDY_VERSION}} 100
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake with clang-tidy option
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -D${{env.CLANG_TIDY_CMAKE_OPTION_NAME}}=ON
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config ${{matrix.build-type}}
+
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{matrix.build-type}} --verbose

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,46 @@
+name: CMake
+
+on: [push]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE
+
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C $BUILD_TYPE

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,6 +1,6 @@
 name: CMake
 
-on: [push]
+on: [push, pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,10 +2,6 @@ name: CMake
 
 on: [push, pull_request]
 
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-
 jobs:
   build:
     # The CMake configure and build commands are platform agnostic and should work equally
@@ -16,6 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        build-type: [Release, Debug]
 
     steps:
     - uses: actions/checkout@v2
@@ -35,17 +32,17 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --config ${{matrix.build-type}}
 
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE --verbose
+      run: ctest -C ${{matrix.build-type}} --verbose

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,10 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,4 +45,4 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE
+      run: ctest -C $BUILD_TYPE --verbose

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You can check 'examples' functions in ['minesweeper_examples.cpp'](/examples/min
 
 * Fixed some standard '#include' directives and checked which classes
   and functions use them.
+* Fixed 'HeaderFilterRegex' for 'clang-tidy'.
 
 ### Version 8.5.2
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ You can check 'examples' functions in ['minesweeper_examples.cpp'](/examples/min
 * Fixed some standard '#include' directives and checked which classes
   and functions use them.
 * Fixed 'HeaderFilterRegex' for 'clang-tidy'.
+* Excluded some unhelpful 'clang-tidy' checks and also gave explanations
+  to all of the excludes.
+* Added ['cmake.yml'](/.github/workflows/cmake.yml), ['clang-format.yml'](/.github/workflows/clang-format.yml) and ['clang-tidy.yml'](/.github/workflows/clang-tidy.yml) GitHub
+  action workflows.
+  * ['cmake.yml'](/.github/workflows/cmake.yml) builds tests on different platforms.
+  * ['clang-format.yml'](/.github/workflows/clang-format.yml) automatically formats the code using 'clang-format'.
+  * ['clang-tidy.yml'](/.github/workflows/clang-tidy.yml) checks the code for typical programming errors.
 
 ### Version 8.5.2
 

--- a/examples/minesweeper_examples.cpp
+++ b/examples/minesweeper_examples.cpp
@@ -4,9 +4,9 @@
 #include <iomanip>   // std::setw
 #include <iostream>  // std::ostream, std::cout, std::endl
 #include <iterator>  // std::vector<int>::iterator
-#include <sstream>   // std::stringstream
-#include <utility> // std::move
 #include <memory>    // std::unique_ptr, std::make_unique (C++14)
+#include <sstream>   // std::stringstream
+#include <utility>   // std::move
 
 #include <minesweeper/game.h>
 #include <minesweeper/i_random.h>

--- a/include/minesweeper/game.h
+++ b/include/minesweeper/game.h
@@ -275,6 +275,6 @@ class Game {
 
 } // namespace minesweeper
 
-#include "game.tpp"
+#include <minesweeper/game.tpp>
 
 #endif // MINESWEEPER_GAME_H

--- a/include/minesweeper/type_traits.h
+++ b/include/minesweeper/type_traits.h
@@ -2,7 +2,7 @@
 #define MINESWEEPER_TYPE_TRAITS_H
 
 #include <type_traits> // std::enable_if, std::false_type, std::true_type
-#include <utility> // std::declval
+#include <utility>     // std::declval
 
 namespace minesweeper {
 

--- a/src/minesweeper/game.cpp
+++ b/src/minesweeper/game.cpp
@@ -1,11 +1,11 @@
 #include <algorithm> // std::max, std::remove
 #include <cassert>   // assert
 #include <iomanip>   // std::setw
+#include <iostream>  // std::istream, std::ostream, std::endl
 #include <memory>    // std::unique_ptr, std::make_unique (C++14)
 #include <numeric>   // std::iota
-#include <iostream>    // std::istream, std::ostream, std::endl
 #include <stdexcept> // std::out_of_range, std::invalid_argument
-#include <string>  // std::string, std::to_string
+#include <string>    // std::string, std::to_string
 #include <utility>   // std::pair, std::move
 #include <vector>    // std::vector
 

--- a/tests/minesweeper_game_tests.cpp
+++ b/tests/minesweeper_game_tests.cpp
@@ -1,12 +1,12 @@
-#include <fstream> // std::ifstream
-#include <list>    // std::list
-#include <sstream> // std::stringstream, std::ostringstream, std::istringstream
-#include <string>  // std::string, std::to_string
-#include <vector>  // std::vector
 #include <algorithm> // std::find, std::iter_swap
+#include <cmath>     // std::abs
+#include <fstream>   // std::ifstream
+#include <list>      // std::list
+#include <sstream>   // std::stringstream, std::ostringstream, std::istringstream
 #include <stdexcept> // std::out_of_range, std::invalid_argument
-#include <utility> // std::move
-#include <cmath> // std::abs
+#include <string>    // std::string, std::to_string
+#include <utility>   // std::move
+#include <vector>    // std::vector
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Add GitHub action workflows into develop branch

* Fixed 'HeaderFilterRegex' for 'clang-tidy'.

* Excluded some unhelpful 'clang-tidy' checks and also gave explanations
  to all of the excludes.

* Added 'cmake.yml', 'clang-format.yml' and 'clang-tidy.yml' GitHub
  action workflows.

  * 'cmake.yml' builds tests on different platforms.

  * 'clang-format.yml' automatically formats the code using 'clang-format'.

  * 'clang-tidy.yml' checks the code for typical programming errors.